### PR TITLE
Hacky fix for 404 error in docs reference

### DIFF
--- a/main.md
+++ b/main.md
@@ -6,7 +6,7 @@ Waku is the communication layer for Web3. Decentralized communication that scale
 
 Private. Secure. Runs anywhere.
 
-[Check the docs](/docs/index.md)
+[Check the docs](/docs)
 
 ## What is Waku?
 
@@ -35,7 +35,7 @@ Its relay protocol implements pub/sub over libp2p, and also introduces additiona
 
 This makes it ideal for running a p2p protocol on mobile, or in other similarly resource-restricted environments.
 
-[Learn more about Waku](/docs/index.md)
+[Learn more about Waku](/docs)
 
 ## Use Waku Now
 


### PR DESCRIPTION
As deployed at <https://waku.org>, `/docs/index.md` returns a 404, but
`/docs` works.  Use it for the time being.

Untested. 

Supersedes <https://github.com/acid-info/waku.org/pull/14>.