### PR TITLE
add jenkinsfile and CNAME file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,85 @@
+pipeline {
+  agent { label 'linux' }
+
+  options {
+    disableConcurrentBuilds()
+    /* Necessary for logos-side-builder local_folder source type. */
+    checkoutToSubdirectory('src')
+    /* manage how many builds we keep */
+    buildDiscarder(logRotator(
+      numToKeepStr: '20',
+      daysToKeepStr: '30',
+    ))
+  }
+
+  environment {
+    /* Mode of logos-site-builder for copying site source from already checked out repo.
+     * TODO: Avoid copying anything at all, make checkout site of into `docs` folder work. */
+    CONTENT_SOURCE_TYPE  = 'local_folder'
+    CONTENT_SOURCE_URL = '../src'
+    GIT_COMMITTER_NAME = 'status-im-auto'
+    GIT_COMMITTER_EMAIL = 'auto@status.im'
+    /* dev page settings */
+    DEV_SITE = 'dev.waku.org'
+    DEV_HOST = 'jenkins@node-01.do-ams3.sites.misc.statusim.net'
+    SCP_OPTS = 'StrictHostKeyChecking=no'
+  }
+
+  stages {
+    stage('Clone Builder') {
+      steps {
+        dir('builder') {
+          checkout([$class: 'GitSCM',
+            branches: [[name: 'v0']],
+            userRemoteConfigs: [[url: 'https://github.com/acid-info/logos-site-builder']]])
+        }
+      }
+    }
+
+    stage('Install') {
+      steps {
+        dir('builder') {
+           sh 'yarn install'
+        }
+      }
+    }
+
+    stage('Build') {
+      steps {
+        dir('builder') {
+           sh 'yarn build'
+        }
+      }
+    }
+
+    stage('Publish Prod') {
+      when { expression { env.GIT_BRANCH ==~ /.*master/ } }
+      steps {
+        dir('src') {
+          sh 'cp -r ../builder/out ./'
+          sshagent(credentials: ['status-im-auto-ssh']) {
+            sh "ghp-import -p out"
+          }
+        }
+      }
+    }
+
+    stage('Publish Devel') {
+      when { expression { env.GIT_BRANCH ==~ /.*develop/ } }
+      steps {
+        dir('builder') {
+          sshagent(credentials: ['jenkins-ssh']) {
+            sh """
+              rsync -e 'ssh -o ${SCP_OPTS}' -r --delete out/. \
+                ${env.DEV_HOST}:/var/www/${env.DEV_SITE}/
+            """
+          }
+        }
+      }
+    }
+  }
+
+  post {
+    cleanup { cleanWs() }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Content of https://waku.org website.
 
 ## Continuous Integration
 
-- `develop` branch is pushed to [dev.waku.org](https://dev.waku.org) via GitHub Action.
-- `master` branch is pushed to [waku.org](https://waku.org) via GitHub Action.
+* `master` branch is deployed to https://waku.org by [CI](https://ci.infra.status.im/job/website/job/waku.org/).
+* `develop` branch is deployed to https:/dev.waku.org by [CI](https://ci.infra.status.im/job/website/job/dev.waku.org/).
 
 ## Format & spelling checks
 

--- a/static-assets/CNAME
+++ b/static-assets/CNAME
@@ -1,0 +1,1 @@
+waku.org


### PR DESCRIPTION
The current implementation of the site builder requires content repo to be submited as a zip file for production using env vars `CONTENT_SOURCE_TYPE=git` and `CONTENT_SOURCE_URL=repo-link.zip` which is not considered a best practice. Due to this, a race condition may occur during the build process if another commit is made while the build is in progress which may lead a security flow. To work around this,first, we checkout into `src` using `checkoutToSubdirectory('src')`. Then, we use `local_folder` mode using `CONTENT_SOURCE_TYPE=local_folder` and
`CONTENT_SOURCE_URL=..src` env vars, just like a local develop. `local_folder` mode copies the website files from `src` into `docs` because the site builder is incapable of copying it. We checkout the builder into the `builder` directory and run the `install` and `build` commands inside of that directory. Finally, for publish stages, we copy the `out` directory into the site repo, since the out directory is in the wrong repo.