### PR TITLE
Add github challenges list to Community page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -48,6 +48,10 @@ const config = {
           path: 'root-pages',
         },
         generated: {
+          challenges: {
+            repoArray: [{ owner: 'waku-org', repo: 'bounties' }],
+            githubAccessToken: process.env.GITHUB_ACCESS_TOKEN,
+          },
           jobList: {
             jobBoard: 'waku',
           },

--- a/root-pages/community.mdx
+++ b/root-pages/community.mdx
@@ -6,7 +6,8 @@ displayed_sidebar: null
 sidebar_class_name: hidden
 ---
 
-import { Grid, Box, SocialCard } from '/src/components/mdx'
+import { Grid, Box, SocialCard, GithubChallenges } from '/src/components/mdx'
+import * as challengesData from '/generated/challenges.json'
 
 # Join the community
 
@@ -55,3 +56,7 @@ import { Grid, Box, SocialCard } from '/src/components/mdx'
     </Grid.Item>
   </Grid>
 </Box>
+
+<GithubChallenges
+  challengesData={challengesData}
+/>


### PR DESCRIPTION
Adds github challenges list. A github token is necessary to fetch data from github. We need to ask the infra team to set up an env var with a Github token on the backend. If no token is present, a message is displayed: "No challenges to show"

### How to test this locally

create a .env file at the root of this project, and add a var `GITHUB_ACCESS_TOKEN=<insert token here>`

### Here's what it looks like, with a token:

![Screenshot from 2023-11-17 12-50-21](https://github.com/waku-org/waku.org/assets/9993816/aa660583-1e32-4732-aa4f-f9408266518f)

### Without a token and / or challegens:

![Screenshot from 2023-11-17 12-58-11](https://github.com/waku-org/waku.org/assets/9993816/23970ced-1e64-49f4-83e3-3f2b5fb196c7)


