### PR TITLE
ci: add GitHub token to query bounties

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,15 @@ pipeline {
 
     stage('Build') {
       steps {
-        sh 'yarn build'
+        /* Issues from waku-org/bounties are fetched. */
+        withCredentials([
+          string(
+            credentialsId: 'waku-org-bounties-access-gh-token',
+            variable: 'GITHUB_ACCESS_TOKEN'
+          ),
+        ]) {
+          sh 'yarn build'
+        }
         sh "echo ${env.PROD_SITE} > build/CNAME"
       }
     }


### PR DESCRIPTION
Token has limited access to issues in this repo: https://github.com/waku-org/bounties

![image](https://github.com/waku-org/waku.org/assets/2212681/5274898f-7c45-4166-aa41-1cf3eccb0d9f)