### PR TITLE
ci: add genaration of build.json matadate file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,6 @@
+#!/usr/bin/env groovy
+library 'status-jenkins-lib@v1.8.8'
+
 pipeline {
   agent { label 'linux' }
 
@@ -27,7 +30,7 @@ pipeline {
     }
 
     stage('Build') {
-      steps {
+      steps { script {
         /* Issues from waku-org/bounties are fetched. */
         withCredentials([
           string(
@@ -37,8 +40,11 @@ pipeline {
         ]) {
           sh 'yarn build'
         }
-        sh "echo ${env.PROD_SITE} > build/CNAME"
-      }
+        dir('build') {
+          sh "echo ${env.PROD_SITE} > CNAME"
+          jenkins.genBuildMetaJSON()
+        }
+      } }
     }
 
     stage('Publish Prod') {


### PR DESCRIPTION
Useful for debugging missing deployments. Result:
```
 > curl -sL dev.waku.org/build.json
{
    "timestamp": "2024-02-19T14:01:56Z",
    "git": {
        "commit": "e4a8b1dec0a53aeebba1e72c2a9337bf0171c8c6",
        "branch": "origin/ci/add-build-meta",
        "url": "git@github.com:waku-org/waku.org.git"
    },
    "build": {
        "id": "159",
        "number": "159",
        "name": "website/waku.org",
        "slave": "linux-02",
        "url": "https://ci.infra.status.im/job/website/job/waku.org/159/"
    }
}
```