### PR TITLE
feat: use two deploy branches for CI builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,12 @@ $ yarn serve
 
 ## CI/CD
 
-- The `master` branch is automatically deployed to the production server (e.g., logos.co) through [CI](https://ci.infra.status.im)
-- The `develop` branch is automatically deployed to the staging server (e.g., dev.logos.co) through [CI](https://ci.infra.status.im)
+- [CI builds](https://ci.infra.status.im/job/website/job/waku.org/) `master` and pushes to `deploy-master` branch, which is hosted at <https://waku.org/>.
+- [CI builds](https://ci.infra.status.im/job/website/job/waku.org/) `develop` and pushes to `deploy-develop` branch, which is hosted at <https://dev.waku.org/>.
 
+The hosting is done using [Caddy server with Git plugin for handling GitHub webhooks](https://github.com/status-im/infra-misc/blob/master/ansible/roles/caddy-git).
+
+Information about deployed build can be also found in `/build.json` available on the website.
 
 ## Change Process
 


### PR DESCRIPTION
This way we have two branches on GitHub that reflect the state of the website after CI build has finished and pushed. See README.