### PR TITLE
Add Waku subreddit link to footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -167,6 +167,10 @@ const config = {
                 href: 'https://t.me/waku_org',
                 label: 'Telegram',
               },
+              {
+                href: 'https://www.reddit.com/r/waku/',
+                label: 'Reddit',
+              },
             ],
           },
           {


### PR DESCRIPTION
Adds Waku subreddit link to footer.
![Screenshot 2025-06-27 at 08 23 19](https://github.com/user-attachments/assets/dd798ad0-bd35-4f35-abdf-aaa0d2094c5d)
