### PR TITLE
Replace "Join Us" with "Job Openings"

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -102,8 +102,8 @@ const config = {
             href: 'https://docs.waku.org',
           },
           {
-            label: 'Join Us',
-            to: '/join-us',
+            label: 'Job Openings',
+            to: '/jobs',
           },
           {
             label: 'Events',
@@ -188,7 +188,7 @@ const config = {
           {
             items: [
               {
-                to: '/join-us',
+                to: '/jobs',
                 label: 'Work with Us',
               },
               {

--- a/root-pages/jobs.mdx
+++ b/root-pages/jobs.mdx
@@ -1,5 +1,5 @@
 ---
-title: Join Us
+title: Job Openings
 hide_title: true
 pagination_prev: null
 pagination_next: null


### PR DESCRIPTION
Because we want you to join us, but not necessary as paid CC.