### PR TITLE
Add discord and github cta buttons

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -41,7 +41,21 @@ import Link from '@docusaurus/Link'
         target="_blank"
         onClick={() => umami.track('Get Involved', { source: 'hero' })}
       >
-        Get Involved
+        Docs
+      </HeroAction>
+      <HeroAction
+        href="https://github.com/waku-org"
+        target="_blank"
+        onClick={() => umami.track('Github', { source: 'hero' })}
+      >
+        Github
+      </HeroAction>
+      <HeroAction
+        href="https://discord.waku.org/"
+        target="_blank"
+        onClick={() => umami.track('Discord', { source: 'hero' })}
+      >
+        Discord
       </HeroAction>
     </HeroActions>
   </HeroInfo>


### PR DESCRIPTION
Adds discord and github buttons to CTA section.

### New views

Desktop:

<img width="1446" height="1006" alt="Screenshot 2025-07-11 at 17 40 14" src="https://github.com/user-attachments/assets/060e2795-0670-4214-9386-56bf3e42ed72" />


Mobile:

<img width="974" height="1104" alt="Screenshot 2025-07-11 at 17 42 56" src="https://github.com/user-attachments/assets/5e262234-e2ce-4a7b-96bf-cfc0ce6e3ec0" />

